### PR TITLE
Fix Save Loading Behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kerbal-transfer-illustrator",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.9.3",


### PR DESCRIPTION
To avoid an error, ignore crafts/objects orbiting a body with an invalid reference ID when loading a save.