### PR TITLE
Add second plane change strategy

### DIFF
--- a/hq
+++ b/hq
@@ -1,0 +1,651 @@
+[33mcommit b1d0140b2c90fd60aaf95b6c1e81ee56a8fc8631[m[33m ([m[1;36mHEAD -> [m[1;32mplanechange2[m[33m)[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Sun Apr 16 19:20:14 2023 -0500
+
+    add second plane change strategy
+
+[33mcommit e3d250e09e8cd37b28caa8f74d5b771ac589cd13[m[33m ([m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mmain[m[33m)[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Fri Mar 10 12:05:36 2023 -0600
+
+    Fix Save Loading Behavior (#33)
+    
+    * don't load crafts with invalid bodies
+    
+    * v0.12.6
+
+[33mcommit bcf92cf3864bfddbe385100958b436cd0967ba2a[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Sun Feb 26 22:18:30 2023 -0600
+
+    Add support for loading KSP2 saves (#32)
+    
+    * support loading KSP2 saves
+    
+    * v0.12.5
+    
+    * avoid recalculating radius
+
+[33mcommit 71129a5a27ca42f3f45384771cc4eb0cde297cbb[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Mon Jan 23 16:47:37 2023 -0600
+
+    fix tracking station lvl display (#31)
+
+[33mcommit 2522eef5be66dbc4543e6f63e9b0bfb4d68defdd[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Mon Jan 23 16:36:20 2023 -0600
+
+    Fix reading antennas from save (#30)
+    
+    * fix reading antennas from save
+    
+    * v0.12.4
+
+[33mcommit e9fa51b62a306e21fc0e49dcf602ca16f4dfe47e[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Sun Jan 8 22:20:31 2023 -0600
+
+    Fix Flyby Search Timeout Issue (#29)
+    
+    * fix timeout issue with flyby search
+    
+    * v0.12.3
+
+[33mcommit 54e4374d25cfe58ece18c37dd8b9f266b8745b96[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Thu Dec 1 22:56:32 2022 -0600
+
+    Add ground stations (#28)
+    
+    * add ground stations
+    
+    * add comm lines to groundstations
+    
+    * add controls for comms
+    
+    * load landed crafts, clean up
+    
+    * tidy up UI with new options
+    
+    * adjust date field widths for 14in
+    
+    * adjust breakpoint
+    
+    * fix height for landed sprites
+    
+    * attempt to fix FP tabs (WIP)
+    
+    * fix OrbitControls updates
+
+[33mcommit 703205bad1c5007156dcff4e77ffe29c13b8a1d1[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Mon Nov 28 17:30:26 2022 -0600
+
+    UI Fixes (#27)
+    
+    * fix flight plan numbering
+    
+    * attempt to improve number fields
+    
+    * fixed behavior with various number fields
+    
+    * v0.12.2
+
+[33mcommit a9cfbe7c145778f07403ac232242f530bd1bd5de[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Wed Nov 16 10:25:46 2022 -0600
+
+    CommNet Visualization (#25)
+    
+    * add CommNet Lines
+    
+    * add CommNet visualization
+    
+    * fix Porkchop Updates
+    
+    * make comms visible by default
+    
+    * v0.12.0
+
+[33mcommit 12d31c1bb2e139f417a846757a6b9106b6260fa3[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Wed Nov 9 09:55:33 2022 -0600
+
+    More Vessel Icons (#24)
+    
+    * add additional properties for vessels
+    
+    * add missing sprites
+
+[33mcommit 9cb85b09928e7a08c05b9a0a70dcaaff1b85fd4c[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Mon Jul 18 22:48:42 2022 -0500
+
+    fix craft info update (again)
+
+[33mcommit 380643472f2ba39ddbaa07e1bbb8e9af062b60d6[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Mon Jul 18 22:30:48 2022 -0500
+
+    fix craft info update
+
+[33mcommit 382cececac75339f3a19d69620c42dac9761ad16[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Mon Jul 18 22:01:19 2022 -0500
+
+    fix RSS and KSRSS epoch, better craft info
+
+[33mcommit a0691cdfbec8516037e526e394959a8d03efba20[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Mon Jul 18 14:29:54 2022 -0500
+
+    fix patch optimization bug for certain cases
+
+[33mcommit 7e5b8f88902ca5c2ca6b9d0ec5db78a573bb3e97[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Mon Jul 18 13:49:53 2022 -0500
+
+    Add faster warp options
+
+[33mcommit 81b1094fc27558e4357dc85cc01519eca5ee6c0f[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Thu Jul 14 16:38:36 2022 -0500
+
+    Deep space maneuvers for Multi-Flybys (#22)
+    
+    * add DSN inputs, set up chunked DE
+    
+    * add DSMs for MultiFlyby
+
+[33mcommit 4b4bd4c580eaf5be260bcfac5309a2e5e3822a2b[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Mon Jul 11 15:49:05 2022 -0500
+
+    More texture options (#21)
+    
+    * add more texture options
+    
+    * various fixes
+    
+    * various fixes
+
+[33mcommit cc2c13d280434518fcef6b08b902fa72c61be25f[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Mon Jul 11 12:52:52 2022 -0500
+
+    fix initial rotations for bodies
+
+[33mcommit 96692d52e0c825632593709953c4786b15d07201[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Mon Jul 11 10:52:04 2022 -0500
+
+    fix editor crashes, add body rotation to editor, add tidal locking (#20)
+
+[33mcommit 1a585390e03ea082a7872ea4cf8804ab440162c6[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Mon Jul 11 10:40:14 2022 -0500
+
+    Reduce Netlify bandwidth usage (#19)
+    
+    * avoid serving images via Netlify
+    
+    * fetch icons and textures from the assets branch
+    
+    * fix skybox urls
+
+[33mcommit cb8df86d1fd3194b0add80a4b667f029ebdb19f0[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Sun Jul 10 02:16:41 2022 -0500
+
+    small fixes
+
+[33mcommit 76d87cf9b05f5b3e202449471c4cace735da6c2d[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Sun Jul 10 01:54:07 2022 -0500
+
+    Display improvements (#18)
+    
+    * add skybox
+    
+    * show parent bodies in sub-systems
+    
+    * attempt to get shadows working
+    
+    * improve shadow behavior
+    
+    * fix orbit line colors, small fixes
+
+[33mcommit 9f6cc43369cb63889d11d0b6c2bb0bec011f9042[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Thu Jul 7 12:18:08 2022 -0500
+
+    Patch optimization (#17)
+    
+    * use dimensionless values for transfer refinement objective
+    
+    * overhaul transfer patch optimization
+    
+    * start improving multiflyby patch optimization
+    
+    * overhaul patch optimization for multiflybys, various fixes
+
+[33mcommit 99d88d91c74ef03c143a24e1fe6c3802a0f816ed[m
+Author: theastrogoth <theastrogoth@gmail.com>
+Date:   Tue Jul 5 11:50:41 2022 -0500
+
+    make warp buttons accurate
+
+[33mcommit cd52b995737e09bb6c28d39fa139ddee65510aa0[m
+Author: theastrogoth <theastrogoth@gmail.com>
+Date:   Tue Jul 5 11:15:03 2022 -0500
+
+    small fixes
+
+[33mcommit 94331f6e1df8e79a7f8062b225ac1568e7e4cf27[m
+Author: theastrogoth <theastrogoth@gmail.com>
+Date:   Tue Jul 5 10:51:58 2022 -0500
+
+    add reference line and name labels
+
+[33mcommit ebeee6b4042d9a94117fc9e8824b07a5d425c3d6[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Mon Jul 4 22:11:36 2022 -0500
+
+    add warp buttons, display options
+
+[33mcommit fe4b9405f69baafe8145cd4a4b034f2a1aca71e9[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Thu Jun 30 16:28:47 2022 -0500
+
+    fix suspense for texture loading
+
+[33mcommit fa88fb9a67b52e025a5eee84b46f2391e43a72d6[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Thu Jun 30 13:00:49 2022 -0500
+
+    try readding textures
+
+[33mcommit 1e44d99f0008506a8f72df109760df07e9810c53[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Thu Jun 30 12:49:42 2022 -0500
+
+    fix info popper text color
+
+[33mcommit b46e4aba3b3af0531b1aa2f95151dce7b672b510[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Thu Jun 30 12:18:54 2022 -0500
+
+    test without texture loading
+
+[33mcommit f1b7b1bf728ba72b66e6d9ee8f12dbbdafc9e2e1[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Thu Jun 30 11:59:05 2022 -0500
+
+    update version
+
+[33mcommit 0d3b78428715c16c19e42e1c955f193e069da1c0[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Thu Jun 30 11:58:14 2022 -0500
+
+    click to focus, better zoom behavior, nested systems
+
+[33mcommit 5cb0fa7a9ffa1173d16f8d7d9d18d78a147385aa[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Mon Jun 27 22:18:02 2022 -0500
+
+    fix loading old links
+
+[33mcommit f4ecb265f580a3284e82c3baaad102351a009afb[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Mon Jun 27 21:40:13 2022 -0500
+
+    Use threejs to render orbits/bodies/systems (#16)
+    
+    * install three deps
+    
+    * extra commit
+    
+    * preliminary system display using THREE
+    
+    * start to add orbit gradient to display
+    
+    * add stock textures
+    
+    * add central body orbit lines
+    
+    * add OPM textures, small fixes
+    
+    * add trajectory plotting, switch all pages to new plots
+    
+    * small fix for deploy build
+    
+    * add maneuver and soi sprites
+    
+    * add RSS textures
+    
+    * add vessel sprite
+    
+    * prevent white plot background
+    
+    * add information popper to displays
+    
+    * fix build warnings
+    
+    * fix popper behavior, add more icons
+    
+    * further improve popper placement
+    
+    * update Help info for new plots
+    
+    * add body rotation to configs, add galileo pack
+    
+    * fix custom system ID ordering
+    
+    * new version
+
+[33mcommit 1aa61d00a89e2e27dcd10e27d9ecc4a904ce37e6[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Wed Jun 15 21:57:56 2022 -0500
+
+    fix plotting and json compression problems
+
+[33mcommit 222a9aaf2a512cfe751c481ddb2a8f802b13783c[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Wed Jun 15 15:48:45 2022 -0500
+
+    fix plot size bug for suns
+
+[33mcommit 5e6faaedbd24cb8b4a608653d204b024e8d6c0a5[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Wed Jun 15 15:22:54 2022 -0500
+
+    use type exctraction + compression to shrink URL hash
+
+[33mcommit 13654db74e98239492dda706a954ce8ad208253d[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Tue Jun 14 10:49:37 2022 -0500
+
+    reduce number of renders with equality checks
+
+[33mcommit 80988a6c1e8d4f5daac5bfc643da40807af13e35[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Tue Jun 14 10:22:29 2022 -0500
+
+    fix configs and flight plan links
+
+[33mcommit 260854c77f5521a6fccc2aa70547584ed0d93ec7[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Mon Jun 13 20:28:47 2022 -0500
+
+    UI improvements and Individualized Links (#15)
+    
+    * ui improvements, get link buttons
+    
+    * small UI fixes, fix errors related to hash loading
+    
+    * fix invalid input warnings
+    
+    * fix invalid input warning bug introduced in last commit
+
+[33mcommit 294652cc37457dca3b8e0fd557e5dea0deda1207[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Sat Jun 11 19:39:47 2022 -0500
+
+    avoid invalid selected body name on provided config selection
+
+[33mcommit bcc7b2278c735c8c9f4bc337cfe03c4ac00e828b[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Fri Jun 10 23:25:04 2022 -0500
+
+    try it without onTouchMove
+
+[33mcommit d85f7b30d115ff50ec4ad3fd4d18f441851c6cfd[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Fri Jun 10 23:08:26 2022 -0500
+
+    handle touch events with number inputs
+
+[33mcommit e4df62a4ae6f4bbcf9c62dd45a842696d5672bde[m
+Author: theastrogoth <theastrogoth@gmail.com>
+Date:   Fri Jun 10 17:02:04 2022 -0500
+
+    add option to select from provided configs in editor
+
+[33mcommit 35f0bb95829e9bc8ef80f6cb21d437c215bdffdf[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Fri Jun 10 16:32:35 2022 -0500
+
+    System Editor (#14)
+    
+    * start putting together config editor
+    
+    * add list for BodyConfig selection
+    
+    * add methods to load/sort body configs
+    
+    * make nicer loading buttons
+    
+    * add most of the system editor components
+    
+    * cleaning up
+    
+    * fix a couple more warnings
+    
+    * fix bug for color field when switching bodies
+    
+    * adding/removing of body configs
+    
+    * make add Sun Config and delete bodies buttons
+    
+    * finish up core system editor features
+    
+    * tidying up
+    
+    * accept only one sun upload at a time
+
+[33mcommit 7dec9e42523fa60d6b524a292a87b02fe6e349ee[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Tue Jun 7 16:51:05 2022 -0500
+
+    use MUI Buttons, improve layout, fix useEffect issues (#13)
+
+[33mcommit 034889050eb5b3356aac59793166bc5e272a0f53[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Sun Jun 5 16:02:30 2022 -0500
+
+    actually fix propagation bugs
+
+[33mcommit 5fbce8f00cdeff4985772283816e3ec61bff3a29[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Sat Jun 4 22:54:39 2022 -0500
+
+    Refactor for Netlify (#9)
+    
+    * prepare changes for migrating to Netlify
+    
+    * remove homepage from package.json
+    
+    * refactor for better state management, make use of atomWithURL
+    
+    use atoms wherever feasible to manage state, store system info and flight plan inputs in the URL hash, fix bug in flight propagation, clean up console logs
+    
+    * actually fix flight propagation bug
+    
+    * disable hook deps check to successfully build
+    
+    * remove unneeded deps
+
+[33mcommit d335fc9b953efe0a21b68014fc08fdb107423602[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Thu Jun 2 13:28:43 2022 -0500
+
+    State Management (#8)
+    
+    * use Jotai for better state management
+    
+    * useEffect deps
+    
+    * increment version
+
+[33mcommit 73afb6ab6516a8e2a58af7db1e545d2167f5acdd[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Tue May 31 21:52:33 2022 -0500
+
+    increment version
+
+[33mcommit 1ffecde1426431e3dabc44775ad9792de9511399[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Tue May 31 21:51:08 2022 -0500
+
+    Responsive UI & small fixes (#7)
+    
+    * prepare responsive layout for mobile
+    
+    * fix OrbitControls behavior on system change
+    
+    * add placeholder page for System editor
+    
+    * rearrange OrbitControls buttons
+    
+    * fix outgoing flyby direction calc, small UI fixes
+    
+    * revert propagation intercept tolerance
+
+[33mcommit 03cceb0e364b76221e9441d3690352b1c90e56e4[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Tue May 24 02:17:29 2022 -0500
+
+    Update README.md
+
+[33mcommit f93c7ac86ba47d9b024126b74ccd2d0fd4eda486[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Tue May 24 01:34:32 2022 -0500
+
+    Add more selectable solar systems (#6)
+    
+    * add system selection
+    
+    * add OPM and RSS systems
+    
+    Co-authored-by: theastrogoth <theastrogoth>
+
+[33mcommit c85d68780e0c2ab3f0d12fb3db33dcc81a432c80[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Sun May 22 14:46:12 2022 -0500
+
+    add more info to orbit/body hover text (#5)
+
+[33mcommit 3077edce7f711fac8fd88b18820cf009709ff0d0[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Sun May 22 03:33:27 2022 -0500
+
+    Add Flight Plan Illustrator (#4)
+    
+    * vessel controls
+    
+    * flight plan input fields
+    
+    * finish up vessel controls, propagation fixes
+    
+    * add dark mode support
+    
+    * add past button for Flight Plans
+
+[33mcommit dc320209a566b76efbd5ca86bb153488f2cbd3f0[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Wed May 18 13:41:45 2022 -0500
+
+    add max terrain heights for Kerbol system
+
+[33mcommit 6e16af364a0ce28b1c4becab56b9b451038eed1b[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Wed May 18 12:02:12 2022 -0500
+
+    fix some undesired date field behavior
+
+[33mcommit 6b59872308e8de347774aebc7f770699fb7cc99c[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Tue May 17 14:44:22 2022 -0500
+
+    fix flyby sequence state
+
+[33mcommit a8d50e9d6c16d4221f6e8f41e27539455ae84051[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Tue May 17 13:56:20 2022 -0500
+
+    attempt to fix routing again
+
+[33mcommit b92dcd704b6dcee882026d748207df16dcfe3300[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Tue May 17 13:46:32 2022 -0500
+
+    attempt to fix routing
+
+[33mcommit 05bcb5121efd09daf30f68b08bf182db82d6d80b[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Tue May 17 13:02:12 2022 -0500
+
+    Global state & UI improvements (#3)
+    
+    * add propagation methods
+    
+    * set up outline for Flight Plan Illustrator App
+    
+    * attempt flyby leg duration bounds
+    
+    * add 'global' states and navbar
+    
+    * add copy/paste buttons
+    
+    * fix multiflyby transfer leg bounds
+    
+    * load maneuvers from save file
+    
+    * start setting up flight plan orbit display
+    
+    * add date field to orbit display
+    
+    * add copying of Transfer/MultiFlyby flight plans
+    
+    * remove surface images
+    
+    * add hhmmss option for date fields
+    
+    * remove rounding from orbit display date
+    
+    * fix oberth maneuver labels
+
+[33mcommit c008061b578d664abfd5ca514565cc6c7fda2226[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Wed Mar 30 17:30:07 2022 -0500
+
+    fix loading of first vessel
+
+[33mcommit e5e1b0a3e46d74bd2a7504a3732e72abd367908e[m
+Author: theAstroGoth <52220914+theastrogoth@users.noreply.github.com>
+Date:   Tue Mar 29 09:17:46 2022 -0500
+
+    Oberth Maneuvers (#1)
+    
+    * added 'fast' oberth maneuver calculation
+    
+    * work toward oberth maneuvers for departure/arrival
+    
+    * previous commit had incorrect date due to WSL clock drif
+    
+    * added 'fast' oberth maneuver calculation
+    
+    * previous commit had incorrect date due to WSL clock drif
+    
+    * avoid Oberth maneuvers when not favorable
+    
+    * add radio buttons for depar/arrive type
+    
+    * full implementation of Oberth maneuvers
+
+[33mcommit f8cc44a7b4cd6e93947f62c9289dfcf3061305a0[m
+Author: theAstroGoth <theastrogoth@gmail.com>
+Date:   Fri Mar 25 15:22:48 2022 -0500
+
+    reupload

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,7 +161,7 @@ export const unrefinedTransferAtom = atom(blankInitialTransfer);
 export const porkchopInputsAtom = atom(initialPorkchopInputs);
 export const porkchopPlotDataAtom = atom(initialPorkchopPlotData);
 export const transferControlsOptionsAtom = atom({
-    planeChange:        false,
+    planeChange:        0 as 0 | 1 | 2,
     matchStartMo:       true,
     matchEndMo:         false,
     oberthManeuvers:    false,
@@ -195,7 +195,7 @@ export const multiFlybyAtom = atom(blankMultiFlyby(kspSystem));
 export const unrefinedMultiFlybyAtom = atom(blankMultiFlyby(kspSystem));
 export const evolutionPlotDataAtom = atom({x: [], bestY: [], meanY: []} as EvolutionPlotData);
 export const multiFlybyControlsOptionsAtom = atom({
-  planeChange:        false,
+  planeChange:        0 as 0 | 1 | 2,
   matchStartMo:       false,
   matchEndMo:         false,
   oberthManeuvers:    false,

--- a/src/components/ControlsOptions.tsx
+++ b/src/components/ControlsOptions.tsx
@@ -11,7 +11,7 @@ import Checkbox from "@mui/material/Checkbox";
 import { PrimitiveAtom, useAtom } from "jotai";
 
 export type ControlsOptionsState = {
-    planeChange:        boolean,
+    planeChange:        0 | 1 | 2,
     matchStartMo:       boolean,
     matchEndMo:         boolean,
     oberthManeuvers:    boolean,
@@ -36,6 +36,15 @@ function handleCheckboxChange(setOpts: React.Dispatch<React.SetStateAction<Contr
         }
     )
 }
+function handlePlaneChangeChange(setOpts: React.Dispatch<React.SetStateAction<ControlsOptionsState>>, oldOpts: ControlsOptionsState) {
+    return (
+        (event: React.ChangeEvent<HTMLInputElement>): void => {
+            const newOpts = Object.assign(oldOpts) as ControlsOptionsState;
+            newOpts.planeChange = parseInt(event.target.value) as 0 | 1 | 2;
+            setOpts(newOpts);
+        }
+    )
+}
 
 function ControlsOptions({optsAtom}: {optsAtom: PrimitiveAtom<ControlsOptionsState>}) {
     const [opts, setOpts] = useAtom(optsAtom)
@@ -44,11 +53,12 @@ function ControlsOptions({optsAtom}: {optsAtom: PrimitiveAtom<ControlsOptionsSta
             <FormControl>
                 <FormLabel>Transfer Type</FormLabel>
                 <RadioGroup
-                    defaultValue={false}
-                    onChange={handleChange(setOpts, "planeChange", opts)}
+                    defaultValue={0}
+                    onChange={handlePlaneChangeChange(setOpts, opts)}
                 >
-                    <FormControlLabel value={false} control={<Radio />} label="Ballistic" />
-                    <FormControlLabel value={true}  control={<Radio />} label="Mid-course plane change" />
+                    <FormControlLabel value={0} control={<Radio />} label="Ballistic" />
+                    <FormControlLabel value={1}  control={<Radio />} label="Mid-course plane change (Type 1)" />
+                    <FormControlLabel value={2}  control={<Radio />} label="Mid-course plane change (Type 2)" />
                 </RadioGroup>
             </FormControl>
             <FormControl>

--- a/src/main/libs/multi-flyby-calculator.ts
+++ b/src/main/libs/multi-flyby-calculator.ts
@@ -43,7 +43,7 @@ class MultiFlybyCalculator {
     private _patchOptimizationBounds?:  number[][];
 
     private _ejectionInsertionType:    "fastdirect" | "fastoberth" | "direct" | "oberth";
-    private _planeChange:               boolean;
+    private _planeChange:               0 | 1 | 2;
     private _matchStartMo:              boolean;
     private _matchEndMo:                boolean;
     private _noInsertionBurn:           boolean;
@@ -70,7 +70,7 @@ class MultiFlybyCalculator {
         this._transferBody      = this.bodyFromId(this.commonAttractorId(this._startBody.id, this._endBody.id));
 
         this._ejectionInsertionType = inputs.ejectionInsertionType || "fastdirect";
-        this._planeChange       = inputs.planeChange || false;    
+        this._planeChange       = inputs.planeChange || 0;    
         this._matchStartMo      = inputs.matchStartMo || true;
         this._matchEndMo        = inputs.matchEndMo || false;     
         this._noInsertionBurn   = inputs.noInsertionBurn || false;

--- a/src/main/libs/porkchop-calculator.ts
+++ b/src/main/libs/porkchop-calculator.ts
@@ -20,7 +20,7 @@ class PorkchopCalculator {
     private _nTimes:                number;
 
     private _ejectionInsertionType: "fastdirect" | "direct" | "fastoberth" | "oberth";
-    private _planeChange:           boolean;
+    private _planeChange:           0 | 1 | 2;
     private _matchStartMo:          boolean;
     private _matchEndMo:            boolean;
     private _noInsertionBurn:       boolean;
@@ -44,7 +44,7 @@ class PorkchopCalculator {
         this._nTimes!       = inputs.nTimes;
 
         this._ejectionInsertionType = inputs.ejectionInsertionType === undefined ? "fastdirect" : inputs.ejectionInsertionType;
-        this._planeChange     = inputs.planeChange     === undefined ? false : inputs.planeChange;    
+        this._planeChange     = inputs.planeChange     === undefined ? 0 : inputs.planeChange;    
         this._matchStartMo    = inputs.matchStartMo    === undefined ? true  : inputs.matchStartMo;
         this._matchEndMo      = inputs.matchEndMo      === undefined ? false : inputs.matchEndMo;     
         this._noInsertionBurn = inputs.noInsertionBurn === undefined ? false : inputs.noInsertionBurn;

--- a/src/main/libs/trajectories.ts
+++ b/src/main/libs/trajectories.ts
@@ -48,7 +48,10 @@ namespace Trajectories {
                 vel:  Kepler.velocityAtTrueAnomaly(transferOrbit1, transferBody.stdGravParam, planeChangeNu),
             };
             const n1vec = normalize3(cross3(planeChangePreState.pos, planeChangePreState.vel));
-            const n2vec = normalize3(cross3(planeChangePreState.pos, endPos));
+            let n2vec = normalize3(cross3(planeChangePreState.pos, endPos));
+            if (dot3(n1vec, n2vec) < 0) {
+                n2vec = mult3(n2vec, -1)
+            }
             const rotationAngle = acosClamped(dot3(n1vec, n2vec));
             let rotationAxis = rotationAngle === 0 ? Z_DIR : normalize3(cross3(n1vec, n2vec));
             rotationAxis = isNaN(rotationAxis.x) ? Z_DIR : rotationAxis;
@@ -109,8 +112,11 @@ namespace Trajectories {
                 pos:  Kepler.positionAtTrueAnomaly(transferOrbit2, planeChangeNu),
                 vel:  Kepler.velocityAtTrueAnomaly(transferOrbit2, transferBody.stdGravParam, planeChangeNu),
             };
-            const n1vec = normalize3(cross3(startPos, planeChangePostState.pos));
+            let n1vec = normalize3(cross3(startPos, planeChangePostState.pos));
             const n2vec = normalize3(cross3(planeChangePostState.pos, planeChangePostState.vel));
+            if (dot3(n1vec, n2vec) < 0) {
+                n1vec = mult3(n1vec, -1)
+            }
             const rotationAngle = acosClamped(dot3(n1vec, n2vec));
             console.log(rotationAngle)
             let rotationAxis = rotationAngle === 0 ? Z_DIR : normalize3(cross3(n1vec, n2vec));

--- a/src/main/libs/trajectories.ts
+++ b/src/main/libs/trajectories.ts
@@ -109,12 +109,13 @@ namespace Trajectories {
                 pos:  Kepler.positionAtTrueAnomaly(transferOrbit2, planeChangeNu),
                 vel:  Kepler.velocityAtTrueAnomaly(transferOrbit2, transferBody.stdGravParam, planeChangeNu),
             };
-            const n1vec = normalize3(cross3(planeChangePostState.pos, startPos));
+            const n1vec = normalize3(cross3(startPos, planeChangePostState.pos));
             const n2vec = normalize3(cross3(planeChangePostState.pos, planeChangePostState.vel));
             const rotationAngle = acosClamped(dot3(n1vec, n2vec));
+            console.log(rotationAngle)
             let rotationAxis = rotationAngle === 0 ? Z_DIR : normalize3(cross3(n1vec, n2vec));
             rotationAxis = isNaN(rotationAxis.x) ? Z_DIR : rotationAxis;
-            const oldVel = roderigues(planeChangePostState.vel, rotationAxis, rotationAngle);
+            const oldVel = roderigues(planeChangePostState.vel, rotationAxis, -rotationAngle);
 
             // compute the transfer orbit from the plane change position and post-maneuver velocity;
             const planeChangePreState = {

--- a/src/main/libs/trajectories.ts
+++ b/src/main/libs/trajectories.ts
@@ -6,14 +6,14 @@ import FlybyCalcs from './flybycalcs';
 
 namespace Trajectories {
     export function transferTrajectory(startOrbit: IOrbit, endOrbit: IOrbit, transferBody: ICelestialBody, startDate: number, flightTime: number, endDate: number, 
-                                       planeChange: boolean, startPatchPosition: Vector3 = vec3(0,0,0), endPatchPosition: Vector3 = vec3(0,0,0)): Trajectory {
+                                       planeChange: number, startPatchPosition: Vector3 = vec3(0,0,0), endPatchPosition: Vector3 = vec3(0,0,0)): Trajectory {
         
         const startState = Kepler.orbitToStateAtDate(startOrbit, transferBody, startDate);
         const endState   = Kepler.orbitToStateAtDate(endOrbit,   transferBody, endDate); 
         const startPos = add3(startState.pos, startPatchPosition);
         const endPos   = add3(endState.pos,   endPatchPosition);
 
-        if(planeChange) { // for plane-change-style transfer...
+        if(planeChange === 1) { // for plane-change-style transfer, matching the starting orbital plane in the first half...
             // project the end position to the perifocal plane of the pre-transfer orbit, and compute a transfer
             let planeEndPos = Kepler.rotateToPerifocalFromInertial(endPos, startOrbit);
             planeEndPos = Kepler.rotateToInertialFromPerifocal(vec3(planeEndPos.x, planeEndPos.y, 0.0), startOrbit);
@@ -82,6 +82,68 @@ namespace Trajectories {
                                 maneuvers:      [departManeuver, planeManeuver, arriveManeuver]};
                    
             return trajectory;    
+        } else if(planeChange === 2) { // for plane-change-style transfer, matching the target orbital plane in the second half... 
+            // project the start position to the perifocal plane of the post-transfer orbit, and compute a transfer
+            let planeStartPos = Kepler.rotateToPerifocalFromInertial(startPos, endOrbit);
+            planeStartPos = Kepler.rotateToInertialFromPerifocal(vec3(planeStartPos.x, planeStartPos.y, 0.0), endOrbit);
+
+            const v2 = Lambert.solve(planeStartPos, endPos, flightTime, transferBody).v2;
+            // state at the beginning of the transfer
+            const arriveState: OrbitalState = {
+                date: endDate,
+                pos:  endPos,
+                vel:  v2,
+            }
+            const transferOrbit2 = Kepler.stateToOrbit(arriveState, transferBody);
+            
+            // identify the true anomaly and date at the plane change (use PI/2 prior to target encounter)
+            const endNu = Kepler.angleInOrbitPlane(endPos, transferOrbit2);
+            const startNu = Kepler.angleInOrbitPlane(planeStartPos, transferOrbit2);
+
+            const planeChangeNu = startNu + Math.max(0.0, (wrapAngle(endNu - startNu) - HALF_PI));
+            const planeChangeDate = Kepler.trueAnomalyToOrbitDate(planeChangeNu, transferOrbit2, startDate);
+
+            // rotate the velocity vector at the plane change location to hit the target at encounter
+            const planeChangePostState = {
+                date: planeChangeDate,
+                pos:  Kepler.positionAtTrueAnomaly(transferOrbit2, planeChangeNu),
+                vel:  Kepler.velocityAtTrueAnomaly(transferOrbit2, transferBody.stdGravParam, planeChangeNu),
+            };
+            const n1vec = normalize3(cross3(planeChangePostState.pos, startPos));
+            const n2vec = normalize3(cross3(planeChangePostState.pos, planeChangePostState.vel));
+            const rotationAngle = acosClamped(dot3(n1vec, n2vec));
+            let rotationAxis = rotationAngle === 0 ? Z_DIR : normalize3(cross3(n1vec, n2vec));
+            rotationAxis = isNaN(rotationAxis.x) ? Z_DIR : rotationAxis;
+            const oldVel = roderigues(planeChangePostState.vel, rotationAxis, rotationAngle);
+
+            // compute the transfer orbit from the plane change position and post-maneuver velocity;
+            const planeChangePreState = {
+                date: planeChangeDate, 
+                pos: planeChangePostState.pos, 
+                vel: oldVel,
+            };
+            const transferOrbit1 = Kepler.stateToOrbit(planeChangePreState, transferBody);
+
+            // state at end of transfer
+            let departState = Kepler.orbitToStateAtDate(transferOrbit1, transferBody, startDate);
+            if(isNaN(departState.pos.x)) {  // in case Newton root solving fails for the inverse Kepler equation (near parabolic orbits?)
+                const arriveNu = Kepler.angleInOrbitPlane(endPos, transferOrbit2);
+                departState = {
+                    date: endDate,
+                    pos:  endPos,
+                    vel:  Kepler.velocityAtTrueAnomaly(transferOrbit2, transferBody.stdGravParam, arriveNu),
+                };
+            }
+            // prepare maneuvers
+            const departManeuver = Kepler.maneuverFromOrbitalStates(startState, departState);
+            const arriveManeuver = Kepler.maneuverFromOrbitalStates(arriveState, endState);
+            const planeManeuver  = Kepler.maneuverFromOrbitalStates(planeChangePreState, planeChangePostState)
+
+            const trajectory = {orbits:         [transferOrbit1, transferOrbit2],
+                                intersectTimes: [startDate, planeChangeDate, endDate],
+                                maneuvers:      [departManeuver, planeManeuver, arriveManeuver]};
+                   
+            return trajectory;  
         } else {
             const {v1, v2} = Lambert.solve(startPos, endPos, flightTime, transferBody)
 

--- a/src/main/libs/transfer-calculator.ts
+++ b/src/main/libs/transfer-calculator.ts
@@ -32,7 +32,7 @@ class TransferCalculator {
 
     private _ejectionInsertionType:     "fastdirect" | "direct" | "fastoberth" | "oberth";
 
-    private _planeChange:               boolean;
+    private _planeChange:               0 | 1 | 2;
     private _noInsertionBurn:           boolean;
     private _matchStartMo:              boolean;
     private _matchEndMo:                boolean;
@@ -76,7 +76,7 @@ class TransferCalculator {
         this._soiPatchBodies = soiPatchSequence.map(i => this.bodyFromId(i) as IOrbitingBody);
 
         this._ejectionInsertionType = inputs.ejectionInsertionType === undefined ? "fastdirect" : inputs.ejectionInsertionType;
-        this._planeChange     = inputs.planeChange     === undefined ? false : inputs.planeChange;    
+        this._planeChange     = inputs.planeChange     === undefined ? 0 : inputs.planeChange;    
         this._matchStartMo    = inputs.matchStartMo    === undefined ? true  : inputs.matchStartMo;
         this._matchEndMo      = inputs.matchEndMo      === undefined ? false : inputs.matchEndMo;     
         this._noInsertionBurn = inputs.noInsertionBurn === undefined ? false : inputs.noInsertionBurn;

--- a/src/main/objects/multiflyby.ts
+++ b/src/main/objects/multiflyby.ts
@@ -22,7 +22,7 @@ class MultiFlyby implements IMultiFlyby {
     readonly soiPatchPositions:      Vector3[];
     readonly flybyDurations:         { inTime: number; outTime: number; total: number; }[];
     readonly ejectionInsertionType:  "fastdirect" | "direct" | "fastoberth" | "oberth";
-    readonly planeChange:            boolean;
+    readonly planeChange:            0 | 1 | 2;;
     readonly matchStartMo:           boolean;
     readonly matchEndMo:             boolean;
     readonly noInsertionBurn:        boolean;

--- a/src/main/objects/porkchop.ts
+++ b/src/main/objects/porkchop.ts
@@ -10,7 +10,7 @@ export class Porkchop implements IPorkchop {
     readonly flightTimes:           number[];
     readonly deltaVs:               number[][];
     readonly ejectionInsertionType: "fastdirect" | "direct" | "fastoberth" | "oberth";
-    readonly planeChange:           boolean;
+    readonly planeChange:           0 | 1 | 2;
     readonly noInsertionBurn:       boolean;
     readonly matchStartMo:          boolean;
     readonly matchEndMo:            boolean;

--- a/src/main/objects/transfer.ts
+++ b/src/main/objects/transfer.ts
@@ -21,7 +21,7 @@ export class Transfer implements ITransfer {
     readonly deltaV:                    number;
     readonly soiPatchPositions:         Vector3[];
     readonly ejectionInsertionType:     "fastdirect" | "direct" | "fastoberth" | "oberth";
-    readonly planeChange:               boolean;
+    readonly planeChange:               0 | 1 | 2;
     readonly noInsertionBurn:           boolean;
     readonly matchStartMo:              boolean;
     readonly matchEndMo:                boolean;

--- a/src/pages/Flyby.tsx
+++ b/src/pages/Flyby.tsx
@@ -51,7 +51,7 @@ export function blankMultiFlyby(system: SolarSystem): MultiFlyby {
     soiPatchPositions:      [],
     flybyDurations:         [],
     ejectionInsertionType:  'fastdirect',
-    planeChange:            false,
+    planeChange:            0,
     matchStartMo:           false,
     matchEndMo:             false,
     noInsertionBurn:        false,

--- a/src/pages/Transfer.tsx
+++ b/src/pages/Transfer.tsx
@@ -46,7 +46,7 @@ export function blankTransfer(system: SolarSystem): Transfer {
     maneuverContexts:       [],
     deltaV:                 0.0,
     ejectionInsertionType:  "fastoberth",
-    planeChange:            false,
+    planeChange:            0,
     matchStartMo:           true,
     matchEndMo:             false,
     noInsertionBurn:        false,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -56,7 +56,7 @@ interface ITransfer {
     readonly deltaV:                    number;
     readonly soiPatchPositions:         Vector3[];
     readonly ejectionInsertionType:     "fastdirect" | "direct" | "fastoberth" | "oberth";
-    readonly planeChange:               boolean;
+    readonly planeChange:               0 | 1 | 2;
     readonly noInsertionBurn:           boolean;
     readonly matchStartMo:              boolean;
     readonly matchEndMo:                boolean;
@@ -72,7 +72,7 @@ interface IPorkchop {
     readonly flightTimes:               number[];
     readonly deltaVs:                   number[][];
     readonly ejectionInsertionType:     "fastdirect" | "direct" | "fastoberth" | "oberth",
-    readonly planeChange:               boolean;
+    readonly planeChange:               0 | 1 | 2;
     readonly noInsertionBurn:           boolean;
     readonly matchStartMo:              boolean;
     readonly matchEndMo:                boolean;
@@ -126,7 +126,7 @@ interface IMultiFlyby {
     readonly flybyDurations:        {inTime: number, outTime: number, total: number}[];
     readonly deltaV:                number,
     readonly ejectionInsertionType: "fastdirect" | "direct" | "fastoberth" | "oberth";
-    readonly planeChange:           boolean,
+    readonly planeChange:           0 | 1 | 2;
     readonly matchStartMo:          boolean,
     readonly matchEndMo:            boolean,
     readonly noInsertionBurn:       boolean,
@@ -294,7 +294,7 @@ type TransferInputs = {
     readonly transferBody?:             ICelestialBody;
     readonly soiPatchPositions?:        Vector3[];
     readonly ejectionInsertionType?:    "fastdirect" | "direct" | "fastoberth" | "oberth",
-    readonly planeChange?:              boolean;
+    readonly planeChange?:              0 | 1 | 2;
     readonly matchStartMo?:             boolean;
     readonly matchEndMo?:               boolean;
     readonly noInsertionBurn?:          boolean;
@@ -310,7 +310,7 @@ type PorkchopInputs = {
     flightTimeMax:                      number;
     readonly nTimes:                    number;
     readonly ejectionInsertionType?:    "fastdirect" | "direct" | "fastoberth" | "oberth",
-    readonly planeChange?:              boolean;
+    readonly planeChange?:              0 | 1 | 2;
     readonly matchStartMo?:             boolean;
     readonly matchEndMo?:               boolean;
     readonly noInsertionBurn?:          boolean;
@@ -327,7 +327,7 @@ type MultiFlybyInputs = {
     readonly soiPatchPositions?:        Vector3[];
     readonly flybyDurations?:           {inTime: number, outTime: number, total: number}[],
     readonly ejectionInsertionType?:    "fastdirect" | "direct" | "fastoberth" | "oberth",
-    readonly planeChange?:              boolean;
+    readonly planeChange?:              0 | 1 | 2;
     readonly matchStartMo?:             boolean;
     readonly matchEndMo?:               boolean;
     readonly noInsertionBurn?:          boolean;
@@ -344,7 +344,7 @@ type MultiFlybySearchInputs = {
     readonly flightTimesMax:            number[];
     readonly DSMperLeg:                 number[];
     readonly ejectionInsertionType?:    "fastdirect" | "direct" | "fastoberth" | "oberth",
-    readonly planeChange?:              boolean;
+    readonly planeChange?:              0 | 1 | 2;
     readonly matchStartMo?:             boolean;
     readonly matchEndMo?:               boolean;
     readonly noInsertionBurn?:          boolean;


### PR DESCRIPTION
Add a new mid-course correction strategy, where instead of matching the starting orbit's plane for the first half of the transfer, match the target's orbital plane during the second half of the transfer. 